### PR TITLE
Prefix Chat permission fix

### DIFF
--- a/src/main/java/dev/rono/proxychat/listeners/PlayerChatEvent.java
+++ b/src/main/java/dev/rono/proxychat/listeners/PlayerChatEvent.java
@@ -19,7 +19,7 @@ public class PlayerChatEvent implements Listener {
         for (ChatCommand command : ProxyChat.commands) {
             ProxiedPlayer player = (ProxiedPlayer) e.getSender();
 
-            if (command.useCommandPrefix && e.getMessage().startsWith(command.commandPrefix)) {
+            if (command.useCommandPrefix && e.getMessage().startsWith(command.commandPrefix) && player.hasPermission(command.getPermission())) {
                 String message = (String) e.getMessage().subSequence(1, e.getMessage().length());
                 command.execute((CommandSender) e.getSender(), message.split(" "));
                 e.setCancelled(true);


### PR DESCRIPTION
With this tiny change the Players who do not have permission for e.g. Staffchat can not use the prefix e.g. "#" to write in the staffchat.